### PR TITLE
Enable version handling within api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,10 +49,10 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 	paginator := pagination.NewPaginator(cfg.DefaultLimit, cfg.DefaultOffset, cfg.DefaultMaxLimit)
 
 	if r != nil {
-		r.HandleFunc("/interactives", api.UploadInteractivesHandler).Methods(http.MethodPost)
-		r.HandleFunc("/interactives", paginator.Paginate(api.ListInteractivesHandler)).Methods(http.MethodGet)
-		r.HandleFunc("/interactives/{id}", api.GetInteractiveMetadataHandler).Methods(http.MethodGet)
-		r.HandleFunc("/interactives/{id}", api.UpdateInteractiveHandler).Methods(http.MethodPut)
+		r.HandleFunc("/v1/interactives", api.UploadInteractivesHandler).Methods(http.MethodPost)
+		r.HandleFunc("/v1/interactives", paginator.Paginate(api.ListInteractivesHandler)).Methods(http.MethodGet)
+		r.HandleFunc("/v1/interactives/{id}", api.GetInteractiveMetadataHandler).Methods(http.MethodGet)
+		r.HandleFunc("/v1/interactives/{id}", api.UpdateInteractiveHandler).Methods(http.MethodPut)
 	} else {
 		log.Error(ctx, "api setup error - no router", nil)
 	}

--- a/api/interactives_test.go
+++ b/api/interactives_test.go
@@ -39,7 +39,7 @@ func TestUploadInteractivesHandler(t *testing.T) {
 	}{
 		{
 			title:        "WhenMissingAttachment_ThenStatusBadRequest",
-			req:          httptest.NewRequest(http.MethodPost, "/interactives", nil),
+			req:          httptest.NewRequest(http.MethodPost, "/v1/interactives", nil),
 			responseCode: http.StatusBadRequest,
 		},
 		{
@@ -125,7 +125,7 @@ func TestUploadInteractivesHandler(t *testing.T) {
 			api := api.Setup(ctx, &config.Config{}, nil, nil, tc.mongoServer, tc.kafkaProducer, tc.s3)
 			resp := httptest.NewRecorder()
 			if tc.formFile != "" {
-				tc.req, _ = newfileUploadRequest("/interactives", map[string]string{"metadata1": "value1"}, "attachment", tc.formFile)
+				tc.req, _ = newfileUploadRequest("/v1/interactives", map[string]string{"metadata1": "value1"}, "attachment", tc.formFile)
 			}
 
 			api.UploadInteractivesHandler(resp, tc.req)
@@ -184,7 +184,7 @@ func TestGetInteractiveMetadataHandler(t *testing.T) {
 			ctx := context.Background()
 			api := api.Setup(ctx, &config.Config{}, mux.NewRouter(), nil, tc.mongoServer, nil, nil)
 			resp := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:27050/interactives/%s", interactiveID), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:27050/v1/interactives/%s", interactiveID), nil)
 			api.Router.ServeHTTP(resp, req)
 
 			require.Equal(t, tc.responseCode, resp.Result().StatusCode)

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	AwsRegion                  string        `envconfig:"AWS_REGION"`
 	UploadBucketName           string        `envconfig:"UPLOAD_BUCKET_NAME"`
 	Brokers                    []string      `envconfig:"KAFKA_ADDR"`
+	MinBrokers                 int           `envconfig:"KAFKA_MIN_BROKERS"`
 	KafkaMaxBytes              int           `envconfig:"KAFKA_MAX_BYTES"`
 	KafkaVersion               string        `envconfig:"KAFKA_VERSION"`
 	KafkaSecProtocol           string        `envconfig:"KAFKA_SEC_PROTO"`
@@ -52,13 +53,13 @@ func Get() (*Config, error) {
 		return cfg, nil
 	}
 
-	cfg := &Config{
+	cfg = &Config{
 		BindAddr:                   "localhost:27500",
 		PublishingEnabled:          true,
 		ApiURL:                     "http://localhost:27500",
 		AwsRegion:                  "eu-west-1",
 		UploadBucketName:           "dp-interactives-file-uploads",
-		Brokers:                    []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		Brokers:                    []string{"localhost:9092"},
 		KafkaVersion:               "1.0.2",
 		KafkaMaxBytes:              2000000,
 		InteractivesWriteTopic:     "interactives-import",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,7 +20,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:27500")
 				So(cfg.ApiURL, ShouldResemble, "http://localhost:27500")
-				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092", "localhost:9093", "localhost:9094"})
+				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.KafkaVersion, ShouldEqual, "1.0.2")
 				So(cfg.KafkaSecProtocol, ShouldEqual, "")
 				So(cfg.KafkaMaxBytes, ShouldEqual, 2000000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,57 +7,23 @@ services:
     volumes:
       - ./mongo/entrypoint-initdb.d:/docker-entrypoint-initdb.d
 
-  zookeeper-1:
-    image: confluentinc/cp-zookeeper:6.0.0
-    expose:
-      - 2181
+  zookeeper:
+    image: 'bitnami/zookeeper:latest'
+    restart: unless-stopped
+    ports:
+      - '2181:2181'
     environment:
-      ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+      ALLOW_ANONYMOUS_LOGIN: 'yes'
 
-  kafka-1:
-    image: confluentinc/cp-kafka:6.0.0
-    expose:
-      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
+  kafka:
+    image: 'bitnami/kafka:latest'
     ports:
-      - 9092:9092 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
-    depends_on:
-      - zookeeper-1
+      - '9092:9092'
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
-      KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:19092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-  kafka-2:
-    image: confluentinc/cp-kafka:6.0.0
-    expose:
-      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
-    ports:
-      - 9093:9093 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
-      - zookeeper-1
-    environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
-      KAFKA_BROKER_ID: 2
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:19092,PLAINTEXT_HOST://localhost:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-  kafka-3:
-    image: confluentinc/cp-kafka:6.0.0
-    expose:
-      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
-    ports:
-      - 9094:9094 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
-    depends_on:
-      - zookeeper-1
-    environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
-      KAFKA_BROKER_ID: 3
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:19092,PLAINTEXT_HOST://localhost:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      - zookeeper

--- a/features/getinteractive.feature
+++ b/features/getinteractive.feature
@@ -16,7 +16,7 @@ Feature: Interactives API (Get interactive)
                 }
             ]
             """
-        When I GET "/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+        When I GET "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
         Then I should receive the following JSON response with status "200":
             """
                 {
@@ -42,5 +42,5 @@ Feature: Interactives API (Get interactive)
                 }
             ]
             """
-        When I GET "/interactives/12345678-abb2-4432-ad22-9c23cf7ee222"
+        When I GET "/v1/interactives/12345678-abb2-4432-ad22-9c23cf7ee222"
         Then the HTTP status code should be "404"

--- a/features/listinteractives.feature
+++ b/features/listinteractives.feature
@@ -26,7 +26,7 @@ Feature: Interactives API (List interactives)
                 }
             ]
             """
-        When I GET "/interactives?limit=10&offset=0"
+        When I GET "/v1/interactives?limit=10&offset=0"
         Then I should receive the following JSON response with status "200":
             """
                 {
@@ -53,7 +53,7 @@ Feature: Interactives API (List interactives)
             """
             []
             """
-        When I GET "/interactives?limit=10&offset=0"
+        When I GET "/v1/interactives?limit=10&offset=0"
         Then I should receive the following JSON response with status "200":
             """
                 {

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -1,7 +1,7 @@
 Feature: Interactives API (Update interactive)
 
     Scenario: Update failed if no message body
-        When I PUT "/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+        When I PUT "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
             """
                 {
                     "baddata": true
@@ -10,7 +10,7 @@ Feature: Interactives API (Update interactive)
         Then the HTTP status code should be "400"
 
     Scenario: Update failed if interactive not in DB
-        When I PUT "/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+        When I PUT "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
             """
                 {
                     "importstatus": true,
@@ -35,7 +35,7 @@ Feature: Interactives API (Update interactive)
                     }
                 ]
                 """
-        When I PUT "/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+        When I PUT "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
             """
                 {
                     "importstatus": true,
@@ -60,7 +60,7 @@ Feature: Interactives API (Update interactive)
                     }
                 ]
                 """
-        When I PUT "/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+        When I PUT "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
             """
                 {
                     "importstatus": true,

--- a/features/uploadinteractive.feature
+++ b/features/uploadinteractive.feature
@@ -1,7 +1,7 @@
 Feature: Interactives API (Get interactive)
 
     Scenario: POST an invalid interactive
-        When I POST "/interactives"
+        When I POST "/v1/interactives"
         """
             {
             }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ONSdigital/dp-interactives-api
 go 1.17
 
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
+
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,7 @@ github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -114,9 +114,11 @@ func (e *Init) DoGetKafkaProducer(ctx context.Context, cfg *config.Config) (kafk
 	pConfig := &kafka.ProducerConfig{
 		KafkaVersion:    &cfg.KafkaVersion,
 		MaxMessageBytes: &cfg.KafkaMaxBytes,
-		BrokerAddrs: cfg.Brokers,
-		Topic: cfg.InteractivesWriteTopic,
-		
+		BrokerAddrs:     cfg.Brokers,
+		Topic:           cfg.InteractivesWriteTopic,
+	}
+	if cfg.MinBrokers > 0 {
+		pConfig.MinBrokersHealthy = &cfg.MinBrokers
 	}
 	if cfg.KafkaSecProtocol == "TLS" {
 		pConfig.SecurityConfig = kafka.GetSecurityConfig(


### PR DESCRIPTION
Versioning handled within API - this just adds `/v1/` to all routes. Tested locally.

Streamlined the docker-compose a bit to just one kafka instance too - lift n shift from another repo. 😊 