### PR TITLE
Decouple model from go-api-clients

### DIFF
--- a/features/deleteinteractive.feature
+++ b/features/deleteinteractive.feature
@@ -9,14 +9,8 @@ Feature: Interactives API (Delete interactive)
             """
             [
                 {
-                    "_id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
                     "active": true,
-                    "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                    "last_updated": {
-                        "$date": "2022-02-08T19:04:52.891Z"
-                    },
                     "metadata": "{\"metadata1\":\"XXX\",\"metadata2\":\"YYY\",\"metadata3\":\"ZZZ\"}",
-                    "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                     "state": "ArchiveUploaded"
                 }
             ]

--- a/features/getinteractive.feature
+++ b/features/getinteractive.feature
@@ -5,14 +5,8 @@ Feature: Interactives API (Get interactive)
             """
             [
                 {
-                    "_id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
                     "active": true,
-                    "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                    "last_updated": {
-                        "$date": "2022-02-08T19:04:52.891Z"
-                    },
                     "metadata": "{\"metadata1\":\"XXX\",\"metadata2\":\"YYY\",\"metadata3\":\"ZZZ\"}",
-                    "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                     "state": "ArchiveUploaded"
                 }
             ]
@@ -32,14 +26,8 @@ Feature: Interactives API (Get interactive)
             """
             [
                 {
-                    "_id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
                     "active": true,
-                    "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                    "last_updated": {
-                        "$date": "2022-02-08T19:04:52.891Z"
-                    },
                     "metadata": "{\"metadata1\":\"XXX\",\"metadata2\":\"YYY\",\"metadata3\":\"ZZZ\"}",
-                    "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                     "state": "ArchiveUploaded"
                 }
             ]

--- a/features/listinteractives.feature
+++ b/features/listinteractives.feature
@@ -5,25 +5,16 @@ Feature: Interactives API (List interactives)
             """
             [
                 {
-                    "_id": "671375fa-2fc4-41cc-b845-ad04a56d96a7",
+                    "id": "671375fa-2fc4-41cc-b845-ad04a56d96a7",
                     "active": false,
-                    "file_name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip",
-                    "last_updated": {
-                        "$date": "2022-02-15T18:57:16.359Z"
-                    },
                     "metadata": "{\"metadata1\":\"value1\",\"metadata2\":\"value2\",\"metadata3\":\"value3\"}",
-                    "sha": "rhyCq4GCknxx0nzeqx2LE077Ruo=",
                     "state": "ImportSuccess"
                 },
                 {
-                    "_id": "2683c698-e15b-4d32-a990-ba37d93a4d83",
+                    "id": "2683c698-e15b-4d32-a990-ba37d93a4d83",
                     "active": true,
-                    "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                    "last_updated": {
-                        "$date": "2022-02-15T19:00:46.816Z"
-                    },
+                    "file_name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip",
                     "metadata": "{\"metadata1\":\"val1\",\"metadata2\":\"val2\",\"metadata3\":\"val3\",\"metadata5\":\"val5\"}",
-                    "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                     "state": "ImportSuccess"
                 }
             ]
@@ -35,6 +26,9 @@ Feature: Interactives API (List interactives)
                     "items": [
                         {
                             "id": "2683c698-e15b-4d32-a990-ba37d93a4d83",
+                            "archive": {
+                               "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
+                            },
                             "metadata": {
                                 "metadata1": "val1",
                                 "metadata2": "val2",

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -3,9 +3,9 @@ package steps
 import (
 	"context"
 	"encoding/json"
+	"github.com/ONSdigital/dp-interactives-api/models"
 	"time"
 
-	"github.com/ONSdigital/dp-interactives-api/models"
 	"github.com/cucumber/godog"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -21,18 +21,38 @@ func (c *InteractivesApiComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 }
 
 func (c *InteractivesApiComponent) iHaveTheseInteractives(datasetsJson *godog.DocString) error {
+	var componentTestData []struct {
+		ID           string `json:"id,omitempty"`
+		ArchiveName  string `json:"file_name,omitempty"`
+		State        string `json:"state,omitempty"`
+		Active       bool   `json:"active,omitempty"`
+		MetadataJson string `json:"metadata,omitempty"`
+	}
 
-	interactives := []models.Interactive{}
-
-	err := json.Unmarshal([]byte(datasetsJson.Content), &interactives)
+	err := json.Unmarshal([]byte(datasetsJson.Content), &componentTestData)
 	if err != nil {
 		return err
 	}
 
-	for timeOffset, datasetDoc := range interactives {
-		datasetID := datasetDoc.ID
+	for timeOffset, testData := range componentTestData {
+		mongoInteractive := &models.Interactive{
+			ID: "0d77a889-abb2-4432-ad22-9c23cf7ee796",
+			Archive: &models.Archive{
+				Name: "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
+			},
+			SHA:          "kqA7qPo1GeOJeff69lByWLbPiZM=",
+			State:        testData.State,
+			Active:       &testData.Active,
+			MetadataJson: testData.MetadataJson,
+		}
+		if testData.ID != "" {
+			mongoInteractive.ID = testData.ID
+		}
+		if testData.ArchiveName != "" {
+			mongoInteractive.Archive.Name = testData.ArchiveName
+		}
 
-		if err := c.putDocumentInDatabase(datasetDoc, datasetID, "metadata", timeOffset); err != nil {
+		if err := c.putDocumentInDatabase(mongoInteractive, mongoInteractive.ID, "metadata", timeOffset); err != nil {
 			return err
 		}
 	}

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -26,14 +26,8 @@ Feature: Interactives API (Update interactive)
                 """
                 [
                     {
-                        "_id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
                         "active": false,
-                        "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                        "last_updated": {
-                            "$date": "2022-02-08T19:04:52.891Z"
-                        },
                         "metadata": "{\"metadata1\":\"XXX\",\"metadata2\":\"YYY\",\"metadata3\":\"ZZZ\"}",
-                        "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                         "state": "ArchiveUploaded"
                     }
                 ]
@@ -54,14 +48,8 @@ Feature: Interactives API (Update interactive)
                 """
                 [
                     {
-                        "_id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
                         "active": true,
-                        "file_name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip",
-                        "last_updated": {
-                            "$date": "2022-02-08T19:04:52.891Z"
-                        },
                         "metadata": "{\"metadata1\":\"value1\",\"metadata2\":\"value2\",\"metadata3\":\"value3\"}",
-                        "sha": "kqA7qPo1GeOJeff69lByWLbPiZM=",
                         "state": "ArchiveUploaded"
                     }
                 ]

--- a/models/interactives.go
+++ b/models/interactives.go
@@ -10,27 +10,6 @@ const (
 	ImportSuccess
 )
 
-type Interactive struct {
-	ID           string  `bson:"_id,omitempty"       json:"_id,omitempty"`
-	SHA          string  `bson:"sha,omitempty"       json:"sha,omitempty"`
-	State        string  `bson:"state,omitempty"     json:"state,omitempty"`
-	Active       *bool   `bson:"active,omitempty"    json:"active,omitempty"`
-	MetadataJson string  `bson:"metadata,omitempty"  json:"metadata,omitempty"`
-	Archive      Archive `bson:"archive,omitempty"   json:"archive,omitempty"`
-}
-
-type Archive struct {
-	Name  string  `bson:"name,omitempty"`
-	Size  int64   `bson:"size_in_bytes,omitempty"`
-	Files []*File `bson:"files,omitempty"`
-}
-
-type File struct {
-	Name     string `bson:"name,omitempty"`
-	Mimetype string `bson:"mimetype,omitempty"`
-	Size     int64  `bson:"size_in_bytes,omitempty"`
-}
-
 func (s InteractiveState) String() string {
 	switch s {
 	case ArchiveUploaded:
@@ -46,4 +25,37 @@ func (s InteractiveState) String() string {
 	}
 
 	return "InteractiveStateUnknown"
+}
+
+// HTTP request
+
+type InteractiveUpdate struct {
+	ImportSuccessful *bool       `json:"import_successful,omitempty"`
+	Interactive      Interactive `json:"interactive,omitempty"`
+}
+
+// Mongo/HTTP models
+
+type Interactive struct {
+	ID      string   `bson:"_id,omitempty"           json:"id,omitempty"`
+	Archive *Archive `bson:"archive,omitempty"       json:"archive,omitempty"`
+	//Mongo only
+	SHA          string `bson:"sha,omitempty"       json:"-"`
+	State        string `bson:"state,omitempty"     json:"-"`
+	Active       *bool  `bson:"active,omitempty"    json:"-"`
+	MetadataJson string `bson:"metadata,omitempty"  json:"-"`
+	// HTTP only
+	Metadata map[string]string `bson:"-"            json:"metadata,omitempty"`
+}
+
+type Archive struct {
+	Name  string  `bson:"name,omitempty"          json:"name,omitempty"`
+	Size  int64   `bson:"size_in_bytes,omitempty" json:"size_in_bytes,omitempty"`
+	Files []*File `bson:"files,omitempty"         json:"files,omitempty"`
+}
+
+type File struct {
+	Name     string `bson:"name,omitempty"          json:"name,omitempty"`
+	Mimetype string `bson:"mimetype,omitempty"      json:"mimetype,omitempty"`
+	Size     int64  `bson:"size_in_bytes,omitempty" json:"size_in_bytes,omitempty"`
 }

--- a/models/mapping.go
+++ b/models/mapping.go
@@ -2,23 +2,22 @@ package models
 
 import (
 	"encoding/json"
-	"github.com/ONSdigital/dp-api-clients-go/v2/interactives"
 )
 
-func ToRest(i *Interactive) (*interactives.Interactive, error) {
+func Map(in *Interactive) (*Interactive, error) {
 	metadata := map[string]string{}
-	err := json.Unmarshal([]byte(i.MetadataJson), &metadata)
+	err := json.Unmarshal([]byte(in.MetadataJson), &metadata)
 	if err != nil {
 		return nil, err
 	}
 
-	response := &interactives.Interactive{ID: i.ID, Metadata: metadata}
-	if i.Archive.Name != "" {
-		response.Archive = &interactives.InteractiveArchive{Name: i.Archive.Name}
-		if len(i.Archive.Files) > 0 {
-			response.Archive.Size = i.Archive.Size
-			for _, f := range i.Archive.Files {
-				response.Archive.Files = append(response.Archive.Files, &interactives.InteractiveFile{
+	response := &Interactive{ID: in.ID, Metadata: metadata}
+	if in.Archive.Name != "" {
+		response.Archive = &Archive{Name: in.Archive.Name}
+		if len(in.Archive.Files) > 0 {
+			response.Archive.Size = in.Archive.Size
+			for _, f := range in.Archive.Files {
+				response.Archive.Files = append(response.Archive.Files, &File{
 					Name:     f.Name,
 					Mimetype: f.Mimetype,
 					Size:     f.Size,


### PR DESCRIPTION
Use strategy consistent with other ONS repos - copy and paste models between here and go-api-clients.

Looks good to me locally - sample from list endpoint:

```
{
    "items": [
        {
            "id": "41bdf538-8c68-4fb9-9a1a-403aeeaf183d",
            "archive": {
                "name": "f5XNzqLK76cMwldF835lkCuKO34=/single-interactive.zip",
                "size_in_bytes": 86159,
                "files": [
                    {
                        "name": "single-interactive/index.html",
                        "mimetype": "text/html; charset=utf-8",
                        "size_in_bytes": 47767
                    },
                    {
                        "name": "single-interactive/css/chosen.css",
                        "mimetype": "text/css; charset=utf-8",
                        "size_in_bytes": 12458
                    },
                    {
                        "name": "single-interactive/css/styles.css",
                        "mimetype": "text/css; charset=utf-8",
                        "size_in_bytes": 143763
                    },
                    {
                        "name": "single-interactive/js/DataStructures.Tree.js",
                        "mimetype": "application/javascript",
                        "size_in_bytes": 9105
                    },
                    {
                        "name": "single-interactive/js/chosen.jquery.js",
                        "mimetype": "application/javascript",
                        "size_in_bytes": 47602
                    },
                    {
                        "name": "single-interactive/js/base.js",
                        "mimetype": "application/javascript",
                        "size_in_bytes": 4766
                    },
                    {
                        "name": "single-interactive/js/modernizr.custom.56904.js",
                        "mimetype": "application/javascript",
                        "size_in_bytes": 28463
                    },
                    {
                        "name": "single-interactive/config.json",
                        "mimetype": "application/json",
                        "size_in_bytes": 3042
                    },
                    {
                        "name": "single-interactive/fonts/glyphicons-halflings-regular.woff",
                        "mimetype": "font/woff",
                        "size_in_bytes": 23320
                    },
                    {
                        "name": "single-interactive/exports.csv",
                        "mimetype": "text/csv; charset=utf-8",
                        "size_in_bytes": 9206
                    },
                    {
                        "name": "single-interactive/trade_exports.csv",
                        "mimetype": "text/csv; charset=utf-8",
                        "size_in_bytes": 7545
                    }
                ]
            },
            "metadata": {
                "metadata1": "enim aliqua mollit",
                "metadata2": "sit Lorem voluptate nisi",
                "metadata3": "id consectetur Excepteur ad"
            }
        }
    ],
    "count": 1,
    "offset": 0,
    "limit": 20,
    "total_count": 1
}
```