### PR TITLE
Add ImportMessage attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
+replace github.com/ONSdigital/dp-api-clients-go/v2 => /Users/markryan/workspace/methods/ons/dp-api-clients-go
+
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.96.8
 	github.com/ONSdigital/dp-authorisation v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
-replace github.com/ONSdigital/dp-api-clients-go/v2 => /Users/markryan/workspace/methods/ons/dp-api-clients-go
-
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.96.8
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-mongodb/v3 v3.0.0-beta.4

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.96.8 h1:kABt0aOYuDdazvJwEzhl9cmiJeb/0KCRFRRDI/8/BPk=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.96.8/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9 h1:CHgugduUi/+zp1kvfGIxYurgl3i7nQeBMB/1loVfyLA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.6.3/go.mod h1:CfpOujIEqZS5qON7sWn0LRyiP0V+5l12+2XWHB7S/oo=

--- a/models/interactives.go
+++ b/models/interactives.go
@@ -33,6 +33,7 @@ func (s InteractiveState) String() string {
 
 type InteractiveUpdate struct {
 	ImportSuccessful *bool       `json:"import_successful,omitempty"`
+	ImportMessage    string      `json:"import_message,omitempty"`
 	Interactive      Interactive `json:"interactive,omitempty"`
 }
 
@@ -56,9 +57,10 @@ type Interactive struct {
 	ID      string   `bson:"_id,omitempty"           json:"id,omitempty"`
 	Archive *Archive `bson:"archive,omitempty"       json:"archive,omitempty"`
 	//Mongo only
-	SHA    string `bson:"sha,omitempty"       json:"-"`
-	State  string `bson:"state,omitempty"     json:"-"`
-	Active *bool  `bson:"active,omitempty"    json:"-"`
+	SHA           string  `bson:"sha,omitempty"               json:"-"`
+	State         string  `bson:"state,omitempty"             json:"-"`
+	Active        *bool   `bson:"active,omitempty"            json:"-"`
+	ImportMessage *string `bson:"import_message,omitempty"    json:"-"`
 	// HTTP only
 	Metadata *InteractiveMetadata `bson:"metadata,omitempty"            json:"metadata,omitempty"`
 }


### PR DESCRIPTION
Dev currently broken 🤠  This adds specific attribute for passing back error message - originally put in metadata map.

```
{
  "zip_size": 86159,
  "apiError": "invalid response: 400 from interactives api: http://10.201.4.89:10800/v1/interactives/bdc2c0fe-8503-434b-9815-dbbc591eed6b, body: ",
  "num_files": 11,
  "path": "f5XNzqLK76cMwldF835lkCuKO34=/single-interactive.zip",
  "id": "bdc2c0fe-8503-434b-9815-dbbc591eed6b"
}
```