### PR TITLE
Add interactive URL to response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	PublishingEnabled          bool          `envconfig:"PUBLISHING_ENABLED"`
+	SiteDomain                 string        `envconfig:"SITE_DOMAIN"`
 	ValidateSHAEnabled         bool          `envconfig:"VALIDATE_SHA_ENABLED"`
 	AwsEndpoint                string        `envconfig:"AWS_ENDPOINT"`
 	AwsRegion                  string        `envconfig:"AWS_REGION"`
@@ -63,6 +64,7 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:                   ":27500",
 		PublishingEnabled:          true,
+		SiteDomain:                 "http://localhost:27400",
 		ValidateSHAEnabled:         true,
 		AwsRegion:                  "eu-west-1",
 		UploadBucketName:           "dp-interactives-file-uploads",

--- a/features/getinteractive.feature
+++ b/features/getinteractive.feature
@@ -16,7 +16,9 @@ Feature: Interactives API (Get interactive)
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "sha": "rhyCq4GCknxx0nzeqx2LE077Ruo=",
                     "state": "ArchiveUploaded"
@@ -35,10 +37,13 @@ Feature: Interactives API (Get interactive)
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ArchiveUploaded",
-                    "last_updated":"2021-01-01T00:00:00Z"
+                    "last_updated":"2021-01-01T00:00:00Z",
+                    "url": "http://localhost:27400/interactives/slug-abcde123/embed"
                 }
             """
 

--- a/features/listinteractives.feature
+++ b/features/listinteractives.feature
@@ -12,7 +12,9 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 },
@@ -24,7 +26,9 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 }
@@ -44,13 +48,16 @@ Feature: Interactives API (List interactives)
                             "metadata": {
                                 "title": "title123",
                                 "label": "ad fugiat cillum",
-                                "internal_id": "123"
+                                "internal_id": "123",
+                                "resource_id": "abcde123",
+                                "slug": "slug"
                             },
                             "state": "ImportSuccess",
                             "archive": {
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
-                            "last_updated":"2021-01-01T00:00:01Z"
+                            "last_updated":"2021-01-01T00:00:01Z",
+                            "url": "http://localhost:27400/interactives/slug-abcde123/embed"
                         }
                     ],
                     "count": 1,

--- a/features/listinteractivesfilter.feature
+++ b/features/listinteractivesfilter.feature
@@ -1,6 +1,6 @@
 Feature: Interactives API (List interactives)
 
-    Scenario: GET interactives (title - string)
+    Scenario: GET interactives (filter by label)
         Given I have these interactives:
             """
             [
@@ -11,7 +11,9 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "Title123",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde1",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 },
@@ -23,7 +25,9 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "Title321",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde2",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 }
@@ -43,13 +47,16 @@ Feature: Interactives API (List interactives)
                             "metadata": {
                                 "title": "title123",
                                 "label": "Title321",
-                                "internal_id": "123"
+                                "internal_id": "123",
+                                "resource_id": "abcde2",
+                                "slug": "slug"
                             },
                             "state": "ImportSuccess",
                             "archive": {
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
-                            "last_updated":"2021-01-01T00:00:01Z"
+                            "last_updated":"2021-01-01T00:00:01Z",
+                            "url": "http://localhost:27400/interactives/slug-abcde2/embed"
                         }
                     ],
                     "count": 1,
@@ -59,7 +66,7 @@ Feature: Interactives API (List interactives)
                 }
             """
 
-        Scenario: GET interactives (given a resource_id)
+        Scenario: GET interactives (fliter by resource_id)
         Given I have these interactives:
             """
             [
@@ -70,7 +77,7 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "Title123",
-                        "resource_id": "resid123",
+                        "resource_id": "resid1",
                         "internal_id": "123"
                     },
                     "state": "ImportSuccess"
@@ -83,14 +90,15 @@ Feature: Interactives API (List interactives)
                     "metadata": {
                         "title": "title123",
                         "label": "Title123",
-                        "resource_id": "resid321",
-                        "internal_id": "123"
+                        "resource_id": "resid2",
+                        "internal_id": "123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 }
             ]
             """
-        When As an interactives user with filter I GET '/v1/interactives?filter=%7B%22resource_id%22%3A%20%20%22resid321%22%7D'
+        When As an interactives user with filter I GET '/v1/interactives?filter=%7B%22resource_id%22%3A%20%20%22resid2%22%7D'
         Then I should receive the following JSON response with status "200":
             """
                 {
@@ -104,14 +112,16 @@ Feature: Interactives API (List interactives)
                             "metadata": {
                                 "title": "title123",
                                 "label": "Title123",
-                                "resource_id": "resid321",
-                                "internal_id": "123"
+                                "resource_id": "resid2",
+                                "internal_id": "123",
+                                "slug": "slug"
                             },
                             "state": "ImportSuccess",
                             "archive": {
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
-                            "last_updated":"2021-01-01T00:00:01Z"
+                            "last_updated":"2021-01-01T00:00:01Z",
+                            "url": "http://localhost:27400/interactives/slug-resid2/embed"
                         }
                     ],
                     "count": 1,

--- a/features/steps/api_component.go
+++ b/features/steps/api_component.go
@@ -99,11 +99,9 @@ func NewInteractivesApiComponent(mongoURI string) (*InteractivesApiComponent, er
 	log.Info(context.Background(), "configuration for component test", log.Data{"config": c.Config})
 
 	cfg, _ := config.Get()
-	mongodb := &mongo.Mongo{
-		URI:        strings.Replace(mongoURI, "mongodb://", "", 1),
-		Database:   cfg.MongoConfig.Database,
-		Collection: cfg.MongoConfig.Collection,
-	}
+	cfg.MongoConfig.BindAddr = strings.Replace(mongoURI, "mongodb://", "", 1)
+	cfg.MongoConfig.Database = "interactives-api"
+	mongodb := &mongo.Mongo{Config: cfg}
 
 	if err := mongodb.Init(context.Background(), false, true); err != nil {
 		return nil, err
@@ -124,7 +122,6 @@ func NewInteractivesApiComponent(mongoURI string) (*InteractivesApiComponent, er
 func (c *InteractivesApiComponent) Reset() error {
 	ctx := context.Background()
 
-	c.MongoClient.Database = "interactives-api"
 	if err := c.MongoClient.Init(ctx, false, true); err != nil {
 		log.Warn(ctx, "error initialising MongoClient during Reset", log.Data{"err": err.Error()})
 	}

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -139,7 +139,8 @@ Feature: Interactives API (Update interactive)
                         "resource_id": "resid321",
                         "internal_id": "123"
                     },
-                    "state": "ArchiveUploaded"
+                    "state": "ArchiveUploaded",
+                    "url": "http://localhost:27400/interactives/Title123-resid321/embed"
                 }
             """
 
@@ -189,7 +190,8 @@ Feature: Interactives API (Update interactive)
                         "resource_id": "resid321",
                         "internal_id": "123"
                     },
-                    "state": "ArchiveUploaded"
+                    "state": "ArchiveUploaded",
+                    "url": "http://localhost:27400/interactives/Title321-resid321/embed"
                 }
             """
 

--- a/features/uploadinteractive.feature
+++ b/features/uploadinteractive.feature
@@ -38,6 +38,7 @@ Feature: Interactives API (Get interactive)
                         "resource_id": "AbcdE123",
                         "internal_id": "123"
                     },
-                    "state": "ArchiveUploaded"
+                    "state": "ArchiveUploaded",
+                    "url": "http://localhost:27400/interactives/Title123-AbcdE123/embed"
                 }
             """

--- a/features/web-getinteractive.feature
+++ b/features/web-getinteractive.feature
@@ -40,7 +40,9 @@ Feature: Interactives API (Get interactive) - from public web access
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "sha": "rhyCq4GCknxx0nzeqx2LE077Ruo=",
                     "state": "ArchiveUploaded"
@@ -59,9 +61,12 @@ Feature: Interactives API (Get interactive) - from public web access
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ArchiveUploaded",
-                    "last_updated":"2021-01-01T00:00:00Z"
+                    "last_updated":"2021-01-01T00:00:00Z",
+                    "url": "http://localhost:27400/interactives/slug-abcde123/embed"
                 }
             """

--- a/features/web-listinteractives.feature
+++ b/features/web-listinteractives.feature
@@ -11,7 +11,9 @@ Feature: Interactives API (List interactives) - from public web access
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 },
@@ -23,7 +25,9 @@ Feature: Interactives API (List interactives) - from public web access
                     "metadata": {
                         "title": "title123",
                         "label": "ad fugiat cillum",
-                        "internal_id": "123"
+                        "internal_id": "123",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 },
@@ -35,7 +39,9 @@ Feature: Interactives API (List interactives) - from public web access
                     "metadata": {
                         "title": "publishedTitle",
                         "label": "ad fugiat cillum",
-                        "internal_id": "456"
+                        "internal_id": "456",
+                        "resource_id": "abcde123",
+                        "slug": "slug"
                     },
                     "state": "ImportSuccess"
                 }
@@ -55,10 +61,13 @@ Feature: Interactives API (List interactives) - from public web access
                             "metadata": {
                                 "title": "publishedTitle",
                                 "label": "ad fugiat cillum",
-                                "internal_id": "456"
+                                "internal_id": "456",
+                                "resource_id": "abcde123",
+                                "slug": "slug"
                             },
                             "state": "ImportSuccess",
-                            "last_updated":"2021-01-01T00:00:02Z"
+                            "last_updated":"2021-01-01T00:00:02Z",
+                            "url": "http://localhost:27400/interactives/slug-abcde123/embed"
                         }
                     ],
                     "count": 1,

--- a/models/interactives.go
+++ b/models/interactives.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type InteractiveState int
 
@@ -90,6 +93,14 @@ type Interactive struct {
 	Active        *bool   `bson:"active,omitempty"            json:"-"`
 	SHA           string  `bson:"sha,omitempty"               json:"-"`
 	ImportMessage *string `bson:"import_message,omitempty"    json:"-"`
+	//JSON only
+	URL string `bson:"-" json:"url,omitempty"`
+}
+
+func (i *Interactive) SetURL(domain string) {
+	if i != nil && i.Metadata != nil {
+		i.URL = fmt.Sprintf("%s/%s/%s-%s/embed", domain, "interactives", i.Metadata.HumanReadableSlug, i.Metadata.ResourceID)
+	}
 }
 
 type Archive struct {

--- a/models/interactives_test.go
+++ b/models/interactives_test.go
@@ -1,0 +1,35 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-interactives-api/models"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const domain = "domain"
+
+func TestSetUrl(t *testing.T) {
+	Convey("When we SetUrl on nil interactive", t, func() {
+		var i *models.Interactive
+		i.SetURL(domain)
+	})
+
+	Convey("When we SetUrl on an empty interactive", t, func() {
+		i := &models.Interactive{}
+		i.SetURL(domain)
+		So(i.URL, ShouldEqual, "")
+	})
+
+	Convey("When we SetUrl on an valid interactive", t, func() {
+		i := &models.Interactive{
+			Metadata: &models.InteractiveMetadata{
+				HumanReadableSlug: "slug",
+				ResourceID:        "resource_id",
+			},
+		}
+		i.SetURL(domain)
+		So(i.URL, ShouldEqual, "domain/interactives/slug-resource_id/embed")
+	})
+}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 
-	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-api-clients-go/v2/files"
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-interactives-api/api"
@@ -129,14 +129,7 @@ func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer 
 
 // DoGetMongoDB returns a MongoDB
 func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (api.MongoServer, error) {
-	mongodb := &mongo.Mongo{
-		Collection: cfg.MongoConfig.Collection,
-		Database:   cfg.MongoConfig.Database,
-		URI:        cfg.MongoConfig.BindAddr,
-		Username:   cfg.MongoConfig.Username,
-		Password:   cfg.MongoConfig.Password,
-		IsSSL:      cfg.MongoConfig.IsSSL,
-	}
+	mongodb := &mongo.Mongo{Config: cfg}
 	if err := mongodb.Init(ctx, false, true); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What

Adds `url` to response. This is the URL for rendering the interactive through dp-frontend-router to dp-frontend-interactives-controller: https://github.com/ONSdigital/dp-frontend-router/blob/a265f40c9cae102fb92de882eefdf65ca29cb80a/router/router.go#L97

Root domain is driven by config - currently just `SITE_DOMAIN` but I'm thinking we may need a special case for when `IS_PUBLISHING` (i.e. `publishing.develop...`) too - this is a quick fix if required when we come to plugging in preview work.

### How to review

Sanity check enough i think & test cases pass and cover change.

### Who can review

Anyone
