### PR TITLE
Improve validations to work with combinations of errors

### DIFF
--- a/api/formdata.go
+++ b/api/formdata.go
@@ -12,7 +12,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/ONSdigital/dp-interactives-api/models"
@@ -29,7 +28,6 @@ type FormDataValidator func(*http.Request) error
 var (
 	v                                 = validator.New()
 	conform                           = modifiers.New()
-	alphaNumWithSpacesRegEx           = regexp.MustCompile("^[a-zA-Z0-9\\s]+$")
 	WantOnlyOneAttachmentWithMetadata = func(r *http.Request) error {
 		numOfAttachments, update := len(r.MultipartForm.File), r.FormValue(UpdateFieldKey)
 		if numOfAttachments == 1 && update != "" {

--- a/api/interactives.go
+++ b/api/interactives.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-playground/validator/v10"
 	"io/ioutil"
 	"net/http"
 
@@ -32,18 +31,9 @@ var (
 func (api *API) UploadInteractivesHandler(w http.ResponseWriter, r *http.Request) {
 	// 1. Validate request
 	ctx := r.Context()
-	formDataRequest, err := newFormDataRequest(r, api, WantOnlyOneAttachmentWithMetadata, true)
-	if err != nil {
-		if validationErrs, ok := err.(validator.ValidationErrors); ok {
-			var errs []error
-			for _, vErr := range validationErrs {
-				errs = append(errs, fmt.Errorf("%s", vErr.Namespace()))
-			}
-			api.respond.Errors(ctx, w, http.StatusBadRequest, errs)
-			return
-		}
-
-		api.respond.Error(ctx, w, http.StatusBadRequest, fmt.Errorf("request validation failed %w", err))
+	formDataRequest, errs := newFormDataRequest(r, api, WantOnlyOneAttachmentWithMetadata, true)
+	if errs != nil {
+		api.respond.Errors(ctx, w, http.StatusBadRequest, errs)
 		return
 	}
 
@@ -151,18 +141,9 @@ func (api *API) UpdateInteractiveHandler(w http.ResponseWriter, r *http.Request)
 	id := vars["id"]
 
 	// Validate request
-	formDataRequest, err := newFormDataRequest(r, api, WantAtleastMaxOneAttachmentAndOrMetadata, false)
-	if err != nil {
-		if validationErrs, ok := err.(validator.ValidationErrors); ok {
-			var errs []error
-			for _, vErr := range validationErrs {
-				errs = append(errs, fmt.Errorf("%s", vErr.Namespace()))
-			}
-			api.respond.Errors(ctx, w, http.StatusBadRequest, errs)
-			return
-		}
-
-		api.respond.Error(ctx, w, http.StatusBadRequest, fmt.Errorf("request validation failed %w", err))
+	formDataRequest, errs := newFormDataRequest(r, api, WantAtleastMaxOneAttachmentAndOrMetadata, false)
+	if errs != nil {
+		api.respond.Errors(ctx, w, http.StatusBadRequest, errs)
 		return
 	}
 

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -12,9 +12,9 @@ Feature: Interactives API (Update interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title",
-                        "Interactive.Metadata.Label",
-                        "Interactive.Metadata.InternalID"
+                        "Interactive.Metadata.Title: required",
+                        "Interactive.Metadata.Label: required",
+                        "Interactive.Metadata.InternalID: required"
                     ]
                 }
             """

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -12,9 +12,9 @@ Feature: Interactives API (Update interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title: required",
-                        "Interactive.Metadata.Label: required",
-                        "Interactive.Metadata.InternalID: required"
+                        "interactive.metadata.title: required",
+                        "interactive.metadata.label: required",
+                        "interactive.metadata.internalid: required"
                     ]
                 }
             """

--- a/features/uploadinteractive.feature
+++ b/features/uploadinteractive.feature
@@ -20,9 +20,9 @@ Feature: Interactives API (Get interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title: required",
-                        "Interactive.Metadata.Label: required",
-                        "Interactive.Metadata.InternalID: required"
+                        "interactive.metadata.title: required",
+                        "interactive.metadata.label: required",
+                        "interactive.metadata.internalid: required"
                     ]
                 }
             """
@@ -43,9 +43,9 @@ Feature: Interactives API (Get interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title: required",
-                        "Interactive.Metadata.Label: alphanum",
-                        "Interactive.Metadata.InternalID: alphanum"
+                        "interactive.metadata.title: required",
+                        "interactive.metadata.label: alphanum",
+                        "interactive.metadata.internalid: alphanum"
                     ]
                 }
             """

--- a/features/uploadinteractive.feature
+++ b/features/uploadinteractive.feature
@@ -20,9 +20,9 @@ Feature: Interactives API (Get interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title",
-                        "Interactive.Metadata.Label",
-                        "Interactive.Metadata.InternalID"
+                        "Interactive.Metadata.Title: required",
+                        "Interactive.Metadata.Label: required",
+                        "Interactive.Metadata.InternalID: required"
                     ]
                 }
             """
@@ -43,9 +43,9 @@ Feature: Interactives API (Get interactive)
             """
                 {
                     "errors": [
-                        "Interactive.Metadata.Title",
-                        "Interactive.Metadata.Label",
-                        "Interactive.Metadata.InternalID"
+                        "Interactive.Metadata.Title: required",
+                        "Interactive.Metadata.Label: alphanum",
+                        "Interactive.Metadata.InternalID: alphanum"
                     ]
                 }
             """


### PR DESCRIPTION
### What

The validation was restricted - it would return early so wouldnt work if had a combination of file and model errors. Improved model to return collection of errors.

```
{
    "errors": [
        "file: expecting one attachment with metadata",
        "Interactive.Metadata.Label: alphanum"
    ]
}
```

### How to review

Sanity check

### Who can review

Nimit
