### PR TITLE
Only publish interactive if in desired state

### DIFF
--- a/api/interactives.go
+++ b/api/interactives.go
@@ -237,9 +237,14 @@ func (api *API) UpdateInteractiveHandler(w http.ResponseWriter, r *http.Request)
 			collID = existing.Metadata.CollectionID
 		}
 
+		if *update.Published && !existing.CanPublish() {
+			api.respond.Error(ctx, w, http.StatusBadRequest, fmt.Errorf("error publishing %s to collection %s %s", id, collID, existing.State))
+			return
+		}
+
 		if collID != "" {
 			if err := api.filesService.PublishCollection(ctx, collID); err != nil {
-				api.respond.Error(ctx, w, http.StatusInternalServerError, fmt.Errorf("error publishing collectionID %s %s %w", id, collID, err))
+				api.respond.Error(ctx, w, http.StatusInternalServerError, fmt.Errorf("error publishing %s to collection %s %w", id, collID, err))
 				return
 			}
 			updatedModel.Published = &enabled

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -207,6 +207,47 @@ Feature: Interactives API (Update interactive)
                 }
             """
 
+    Scenario: Publishing fails if not in correct state
+        Given I have these interactives:
+                """
+                [
+                    {
+                        "active": true,
+                        "metadata": {
+                            "label": "Title123",
+                            "title": "Title123",
+                            "slug": "human readable slug",
+                            "resource_id": "resid321",
+                            "internal_id": "123"
+                        },
+                        "state": "ArchiveUploaded"
+                    }
+                ]
+                """
+        When As an interactives user I PUT no file with form-data "/v1/interactives/0d77a889-abb2-4432-ad22-9c23cf7ee796"
+            """
+                {
+                    "published": true,
+                    "metadata": {
+                        "collection_id": "col123",
+                        "label": "Title321",
+                        "title": "Title123",
+                        "slug": "Title321",
+                        "resource_id": "resid321",
+                        "internal_id": "123"
+                    }
+                }
+            """
+        Then the HTTP status code should be "400"
+        And I should receive the following JSON response:
+            """
+                {
+                    "errors": [
+                        "error publishing 0d77a889-abb2-4432-ad22-9c23cf7ee796 to collection col123 ArchiveUploaded"
+                    ]
+                }
+            """
+
     Scenario: Metadata update for a published interactive must fail
         Given I have these interactives:
                 """


### PR DESCRIPTION
### What

Do not allow publish to complete if interactive not in desired state (`ImportSuccess`) - i.e. when the upload process has completed and successful.

@nimitsarup - i think the publish action would be better for a PATCH request 🤔  esp from zebedee otherwise you risk a bad update after doing a rountrip to grab interactive then pass the correct payload. wha ya reckon? 😊 

### How to review

Sanity check

### Who can review

Anyone
