### PR TITLE
Add uri to json response

### DIFF
--- a/features/getinteractive.feature
+++ b/features/getinteractive.feature
@@ -43,7 +43,8 @@ Feature: Interactives API (Get interactive)
                     },
                     "state": "ArchiveUploaded",
                     "last_updated":"2021-01-01T00:00:00Z",
-                    "url": "http://localhost:27300/interactives/slug-abcde123/embed"
+                    "url": "http://localhost:27300/interactives/slug-abcde123/embed",
+                    "uri": "/interactives/slug-abcde123/embed"
                 }
             """
 

--- a/features/listinteractives.feature
+++ b/features/listinteractives.feature
@@ -56,7 +56,8 @@ Feature: Interactives API (List interactives)
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
                             "last_updated":"2021-01-01T00:00:01Z",
-                            "url": "http://localhost:27300/interactives/slug-abcde123/embed"
+                            "url": "http://localhost:27300/interactives/slug-abcde123/embed",
+                            "uri": "/interactives/slug-abcde123/embed"
                         }
                 ]
             """

--- a/features/listinteractivesfilter.feature
+++ b/features/listinteractivesfilter.feature
@@ -55,7 +55,8 @@ Feature: Interactives API (List interactives)
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
                             "last_updated":"2021-01-01T00:00:01Z",
-                            "url": "http://localhost:27300/interactives/slug-abcde2/embed"
+                            "url": "http://localhost:27300/interactives/slug-abcde2/embed",
+                            "uri": "/interactives/slug-abcde2/embed"
                         }
                     ]
             """
@@ -114,7 +115,8 @@ Feature: Interactives API (List interactives)
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
                             "last_updated":"2021-01-01T00:00:01Z",
-                            "url": "http://localhost:27300/interactives/slug-resid2/embed"
+                            "url": "http://localhost:27300/interactives/slug-resid2/embed",
+                            "uri": "/interactives/slug-resid2/embed"
                         }
                     ]
             """
@@ -176,7 +178,8 @@ Feature: Interactives API (List interactives)
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
                             "last_updated":"2021-01-01T00:00:01Z",
-                            "url": "http://localhost:27300/interactives/slug-resid2/embed"
+                            "url": "http://localhost:27300/interactives/slug-resid2/embed",
+                            "uri": "/interactives/slug-resid2/embed"
                         }
                 ]
             """
@@ -234,7 +237,8 @@ Feature: Interactives API (List interactives)
                                 "name": "kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip"
                             },
                             "last_updated":"2021-01-01T00:00:00Z",
-                            "url": "http://localhost:27300/interactives/slug-resid1/embed"
+                            "url": "http://localhost:27300/interactives/slug-resid1/embed",
+                            "uri": "/interactives/slug-resid1/embed"
                         },
                         {
                             "id": "2683c698-e15b-4d32-a990-ba37d93a4d83",
@@ -252,7 +256,8 @@ Feature: Interactives API (List interactives)
                                 "name": "rhyCq4GCknxx0nzeqx2LE077Ruo=/TestMe.zip"
                             },
                             "last_updated":"2021-01-01T00:00:01Z",
-                            "url": "http://localhost:27300/interactives/slug-resid2/embed"
+                            "url": "http://localhost:27300/interactives/slug-resid2/embed",
+                            "uri": "/interactives/slug-resid2/embed"
                         }
                     ]
             """

--- a/features/patchinteractive.feature
+++ b/features/patchinteractive.feature
@@ -101,6 +101,7 @@ Feature: Interactives API (Patch interactive)
                         "internal_id": "123"
                     },
                     "state": "ImportSuccess",
-                    "url": "http://localhost:27300/interactives/Title123-resid321/embed"
+                    "url": "http://localhost:27300/interactives/Title123-resid321/embed",
+                    "uri": "/interactives/Title123-resid321/embed"
                 }
             """

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -154,7 +154,8 @@ Feature: Interactives API (Update interactive)
                         "internal_id": "456"
                     },
                     "state": "ArchiveUploaded",
-                    "url": "http://localhost:27300/interactives/Title456-resid321/embed"
+                    "url": "http://localhost:27300/interactives/Title456-resid321/embed",
+                    "uri": "/interactives/Title456-resid321/embed"
                 }
             """
 
@@ -203,7 +204,8 @@ Feature: Interactives API (Update interactive)
                         "internal_id": "123"
                     },
                     "state": "ArchiveUploaded",
-                    "url": "http://localhost:27300/interactives/Title321-resid321/embed"
+                    "url": "http://localhost:27300/interactives/Title321-resid321/embed",
+                    "uri": "/interactives/Title321-resid321/embed"
                 }
             """
 
@@ -280,6 +282,7 @@ Feature: Interactives API (Update interactive)
                         "internal_id": "123"
                     },
                     "state": "ArchiveUploaded",
-                    "url": "http://localhost:27300/interactives/human readable slug-resid321/embed"
+                    "url": "http://localhost:27300/interactives/human readable slug-resid321/embed",
+                    "uri": "/interactives/human readable slug-resid321/embed"
                 }
             """

--- a/features/uploadinteractive.feature
+++ b/features/uploadinteractive.feature
@@ -79,6 +79,7 @@ Feature: Interactives API (Get interactive)
                         "internal_id": "123"
                     },
                     "state": "ArchiveUploaded",
-                    "url": "http://localhost:27300/interactives/Title123-AbcdE123/embed"
+                    "url": "http://localhost:27300/interactives/Title123-AbcdE123/embed",
+                    "uri": "/interactives/Title123-AbcdE123/embed"
                 }
             """

--- a/features/web-getinteractive.feature
+++ b/features/web-getinteractive.feature
@@ -67,6 +67,7 @@ Feature: Interactives API (Get interactive) - from public web access
                     },
                     "state": "ArchiveUploaded",
                     "last_updated":"2021-01-01T00:00:00Z",
-                    "url": "http://localhost:27300/interactives/slug-abcde123/embed"
+                    "url": "http://localhost:27300/interactives/slug-abcde123/embed",
+                    "uri": "/interactives/slug-abcde123/embed"
                 }
             """

--- a/features/web-listinteractives.feature
+++ b/features/web-listinteractives.feature
@@ -66,7 +66,8 @@ Feature: Interactives API (List interactives) - from public web access
                             },
                             "state": "ImportSuccess",
                             "last_updated":"2021-01-01T00:00:02Z",
-                            "url": "http://localhost:27300/interactives/slug-abcde123/embed"
+                            "url": "http://localhost:27300/interactives/slug-abcde123/embed",
+                            "uri": "/interactives/slug-abcde123/embed"
                         }
                 ]
             """

--- a/models/interactives.go
+++ b/models/interactives.go
@@ -118,11 +118,13 @@ type Interactive struct {
 	SHA    string `bson:"sha,omitempty"               json:"-"`
 	//JSON only
 	URL string `bson:"-" json:"url,omitempty"`
+	URI string `bson:"-" json:"uri,omitempty"`
 }
 
 func (i *Interactive) SetURL(domain string) {
 	if i != nil && i.Metadata != nil {
-		i.URL = fmt.Sprintf("%s/%s/%s-%s/embed", domain, "interactives", i.Metadata.HumanReadableSlug, i.Metadata.ResourceID)
+		i.URI = fmt.Sprintf("/%s/%s-%s/embed", "interactives", i.Metadata.HumanReadableSlug, i.Metadata.ResourceID)
+		i.URL = fmt.Sprintf("%s%s", domain, i.URI)
 	}
 }
 


### PR DESCRIPTION
### What

Add `uri` to response inline with zebedee model - e.g. just path: `/interactives/slug-resource_id/embed` - this could be rendered straight from web/florence (i.e. via frontend router). I think we could drop the url attribute but will leave for now and fix later as needs some frontend to test.

### How to review

Sanity check

### Who can review

Anyone
