### PR TITLE
Remove dp-files-api publish collection call

### DIFF
--- a/api/interactives.go
+++ b/api/interactives.go
@@ -269,11 +269,6 @@ func (api *API) PublishCollectionHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := api.filesService.PublishCollection(ctx, collectionId); err != nil {
-		api.respond.Error(ctx, w, http.StatusInternalServerError, fmt.Errorf("error publishing collection to file server %s %w", collectionId, err))
-		return
-	}
-
 	for _, inter := range ix {
 		inter.Published = &publish
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -32,6 +32,5 @@ type AuthHandler interface {
 
 type FilesService interface {
 	SetCollectionID(ctx context.Context, file, collectionID string) error
-	PublishCollection(ctx context.Context, collectionID string) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 }

--- a/api/mock/filesservice.go
+++ b/api/mock/filesservice.go
@@ -23,9 +23,6 @@ var _ api.FilesService = &FilesServiceMock{}
 // 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
 // 				panic("mock out the Checker method")
 // 			},
-// 			PublishCollectionFunc: func(ctx context.Context, collectionID string) error {
-// 				panic("mock out the PublishCollection method")
-// 			},
 // 			SetCollectionIDFunc: func(ctx context.Context, file string, collectionID string) error {
 // 				panic("mock out the SetCollectionID method")
 // 			},
@@ -39,9 +36,6 @@ type FilesServiceMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *healthcheck.CheckState) error
 
-	// PublishCollectionFunc mocks the PublishCollection method.
-	PublishCollectionFunc func(ctx context.Context, collectionID string) error
-
 	// SetCollectionIDFunc mocks the SetCollectionID method.
 	SetCollectionIDFunc func(ctx context.Context, file string, collectionID string) error
 
@@ -54,13 +48,6 @@ type FilesServiceMock struct {
 			// State is the state argument value.
 			State *healthcheck.CheckState
 		}
-		// PublishCollection holds details about calls to the PublishCollection method.
-		PublishCollection []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// CollectionID is the collectionID argument value.
-			CollectionID string
-		}
 		// SetCollectionID holds details about calls to the SetCollectionID method.
 		SetCollectionID []struct {
 			// Ctx is the ctx argument value.
@@ -71,9 +58,8 @@ type FilesServiceMock struct {
 			CollectionID string
 		}
 	}
-	lockChecker           sync.RWMutex
-	lockPublishCollection sync.RWMutex
-	lockSetCollectionID   sync.RWMutex
+	lockChecker         sync.RWMutex
+	lockSetCollectionID sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -108,41 +94,6 @@ func (mock *FilesServiceMock) CheckerCalls() []struct {
 	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
 	mock.lockChecker.RUnlock()
-	return calls
-}
-
-// PublishCollection calls PublishCollectionFunc.
-func (mock *FilesServiceMock) PublishCollection(ctx context.Context, collectionID string) error {
-	if mock.PublishCollectionFunc == nil {
-		panic("FilesServiceMock.PublishCollectionFunc: method is nil but FilesService.PublishCollection was just called")
-	}
-	callInfo := struct {
-		Ctx          context.Context
-		CollectionID string
-	}{
-		Ctx:          ctx,
-		CollectionID: collectionID,
-	}
-	mock.lockPublishCollection.Lock()
-	mock.calls.PublishCollection = append(mock.calls.PublishCollection, callInfo)
-	mock.lockPublishCollection.Unlock()
-	return mock.PublishCollectionFunc(ctx, collectionID)
-}
-
-// PublishCollectionCalls gets all the calls that were made to PublishCollection.
-// Check the length with:
-//     len(mockedFilesService.PublishCollectionCalls())
-func (mock *FilesServiceMock) PublishCollectionCalls() []struct {
-	Ctx          context.Context
-	CollectionID string
-} {
-	var calls []struct {
-		Ctx          context.Context
-		CollectionID string
-	}
-	mock.lockPublishCollection.RLock()
-	calls = mock.calls.PublishCollection
-	mock.lockPublishCollection.RUnlock()
 	return calls
 }
 

--- a/api/mock/mongo.go
+++ b/api/mock/mongo.go
@@ -40,7 +40,7 @@ var _ api.MongoServer = &MongoServerMock{}
 // 			ListInteractivesFunc: func(ctx context.Context, filter *models.InteractiveFilter) ([]*models.Interactive, error) {
 // 				panic("mock out the ListInteractives method")
 // 			},
-// 			PatchInteractiveFunc: func(contextMoqParam context.Context, patchAttribure mongo.PatchAttribute, interactive *models.Interactive) error {
+// 			PatchInteractiveFunc: func(contextMoqParam context.Context, patchAttribute mongo.PatchAttribute, interactive *models.Interactive) error {
 // 				panic("mock out the PatchInteractive method")
 // 			},
 // 			UpsertInteractiveFunc: func(ctx context.Context, id string, vis *models.Interactive) error {
@@ -72,7 +72,7 @@ type MongoServerMock struct {
 	ListInteractivesFunc func(ctx context.Context, filter *models.InteractiveFilter) ([]*models.Interactive, error)
 
 	// PatchInteractiveFunc mocks the PatchInteractive method.
-	PatchInteractiveFunc func(contextMoqParam context.Context, patchAttribure mongo.PatchAttribute, interactive *models.Interactive) error
+	PatchInteractiveFunc func(contextMoqParam context.Context, patchAttribute mongo.PatchAttribute, interactive *models.Interactive) error
 
 	// UpsertInteractiveFunc mocks the UpsertInteractive method.
 	UpsertInteractiveFunc func(ctx context.Context, id string, vis *models.Interactive) error
@@ -125,8 +125,8 @@ type MongoServerMock struct {
 		PatchInteractive []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
-			// PatchAttribure is the patchAttribure argument value.
-			PatchAttribure mongo.PatchAttribute
+			// PatchAttribute is the patchAttribute argument value.
+			PatchAttribute mongo.PatchAttribute
 			// Interactive is the interactive argument value.
 			Interactive *models.Interactive
 		}
@@ -361,23 +361,23 @@ func (mock *MongoServerMock) ListInteractivesCalls() []struct {
 }
 
 // PatchInteractive calls PatchInteractiveFunc.
-func (mock *MongoServerMock) PatchInteractive(contextMoqParam context.Context, patchAttribure mongo.PatchAttribute, interactive *models.Interactive) error {
+func (mock *MongoServerMock) PatchInteractive(contextMoqParam context.Context, patchAttribute mongo.PatchAttribute, interactive *models.Interactive) error {
 	if mock.PatchInteractiveFunc == nil {
 		panic("MongoServerMock.PatchInteractiveFunc: method is nil but MongoServer.PatchInteractive was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam context.Context
-		PatchAttribure  mongo.PatchAttribute
+		PatchAttribute  mongo.PatchAttribute
 		Interactive     *models.Interactive
 	}{
 		ContextMoqParam: contextMoqParam,
-		PatchAttribure:  patchAttribure,
+		PatchAttribute:  patchAttribute,
 		Interactive:     interactive,
 	}
 	mock.lockPatchInteractive.Lock()
 	mock.calls.PatchInteractive = append(mock.calls.PatchInteractive, callInfo)
 	mock.lockPatchInteractive.Unlock()
-	return mock.PatchInteractiveFunc(contextMoqParam, patchAttribure, interactive)
+	return mock.PatchInteractiveFunc(contextMoqParam, patchAttribute, interactive)
 }
 
 // PatchInteractiveCalls gets all the calls that were made to PatchInteractive.
@@ -385,12 +385,12 @@ func (mock *MongoServerMock) PatchInteractive(contextMoqParam context.Context, p
 //     len(mockedMongoServer.PatchInteractiveCalls())
 func (mock *MongoServerMock) PatchInteractiveCalls() []struct {
 	ContextMoqParam context.Context
-	PatchAttribure  mongo.PatchAttribute
+	PatchAttribute  mongo.PatchAttribute
 	Interactive     *models.Interactive
 } {
 	var calls []struct {
 		ContextMoqParam context.Context
-		PatchAttribure  mongo.PatchAttribute
+		PatchAttribute  mongo.PatchAttribute
 		Interactive     *models.Interactive
 	}
 	mock.lockPatchInteractive.RLock()

--- a/features/steps/api_component.go
+++ b/features/steps/api_component.go
@@ -113,8 +113,7 @@ func NewInteractivesApiComponent(mongoURI string) (*InteractivesApiComponent, er
 	cfg.AuthorisationConfig.PermissionsAPIURL = setupFakePermissionsAPI().URL()
 
 	c.filesService = &apiMock.FilesServiceMock{
-		PublishCollectionFunc: func(ctx context.Context, collectionID string) error { return nil },
-		SetCollectionIDFunc:   func(ctx context.Context, file string, collectionID string) error { return nil },
+		SetCollectionIDFunc: func(ctx context.Context, file string, collectionID string) error { return nil },
 	}
 
 	return c, nil


### PR DESCRIPTION
### What

Remove dp-files-api publish call - already part of standard Zebedee publish flow.

### How to review

Sanity check.

### Who can review

Anyone.
