### PR TITLE
Allow updates to published interactives

### DIFF
--- a/api/interactives.go
+++ b/api/interactives.go
@@ -23,9 +23,7 @@ const (
 var (
 	enabled, disabled        = true, false
 	ErrInvalidBody           = errors.New("body has invalid format")
-	ErrCantUpdateMeta        = errors.New("cannot update metadata for a published interactive")
 	ErrCantDeletePublishedIn = errors.New("cannot delete a published interactive")
-	ErrPubErrNoCollectionID  = errors.New("cannot publish interactive, no collection ID")
 )
 
 func (api *API) UploadInteractivesHandler(w http.ResponseWriter, r *http.Request) {
@@ -139,14 +137,6 @@ func (api *API) UpdateInteractiveHandler(w http.ResponseWriter, r *http.Request)
 		api.respond.Error(ctx, w, http.StatusInternalServerError, fmt.Errorf("error fetching interactive %s %w", id, err))
 		return
 	}
-
-	// fail if attempting to update metadata for a published model
-	if *existing.Published && formDataRequest.hasMetadata() {
-		api.respond.Error(ctx, w, http.StatusForbidden, ErrCantUpdateMeta)
-		return
-	}
-
-	// -- ALL GOOD ABOVE
 
 	// prepare updated model
 	updatedModel := &models.Interactive{

--- a/features/updateinteractive.feature
+++ b/features/updateinteractive.feature
@@ -72,7 +72,7 @@ Feature: Interactives API (Update interactive)
             """
         Then the HTTP status code should be "404"
 
-    Scenario: Slug update for a published interactive is forbidden
+    Scenario: Slug update for a published interactive is allowed - redirect logic means old url will still work
         Given I have these interactives:
                 """
                 [
@@ -95,15 +95,34 @@ Feature: Interactives API (Update interactive)
             """
                 {
                     "metadata": {
-                        "label": "Title123",
-                        "title": "Title123",
-                        "slug": "Title321-update",
-                        "resource_id": "resid321",
-                        "internal_id": "123"
+                        "label": "Title456",
+                        "title": "Title456",
+                        "slug": "Title456",
+                        "resource_id": "resid456",
+                        "internal_id": "456"
                     }
                 }
             """
-        Then the HTTP status code should be "403"
+        Then I should receive the following model response with status "200":
+            """
+                {
+                    "id": "ca99d09c-953a-4fe5-9b0a-51b3d40c01f7",
+                    "published": true,
+                    "archive": {
+                        "name":"kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip"
+                    },
+                    "metadata": {
+                        "title": "Title456",
+                        "label": "Title456",
+                        "slug": "Title456",
+                        "resource_id": "resid321",
+                        "internal_id": "456"
+                    },
+                    "state": "ArchiveUploaded",
+                    "url": "http://localhost:27300/interactives/Title456-resid321/embed",
+                    "uri": "/interactives/Title456-resid321"
+                }
+            """
 
     Scenario: Update success with new file
         Given I have these interactives:
@@ -209,7 +228,7 @@ Feature: Interactives API (Update interactive)
                 }
             """
 
-    Scenario: Metadata update for a published interactive must fail
+    Scenario: Metadata update for a published interactive is allowed - redirect logic means old url will still work
         Given I have these interactives:
                 """
                 [
@@ -232,15 +251,34 @@ Feature: Interactives API (Update interactive)
             """
                 {
                     "metadata": {
-                        "label": "Title321",
-                        "title": "Title123",
-                        "slug": "Title321",
-                        "resource_id": "resid321",
-                        "internal_id": "123"
+                        "label": "Title456",
+                        "title": "Title456",
+                        "slug": "Title456",
+                        "resource_id": "resid456",
+                        "internal_id": "456"
                     }
                 }
             """
-        Then the HTTP status code should be "403"
+        Then I should receive the following model response with status "200":
+            """
+                {
+                    "id": "0d77a889-abb2-4432-ad22-9c23cf7ee796",
+                    "published": true,
+                    "archive": {
+                        "name":"kqA7qPo1GeOJeff69lByWLbPiZM=/docker-vernemq-master.zip"
+                    },
+                    "metadata": {
+                        "label": "Title456",
+                        "slug": "Title456",
+                        "title": "Title456",
+                        "resource_id": "resid321",
+                        "internal_id": "456"
+                    },
+                    "state": "ArchiveUploaded",
+                    "url": "http://localhost:27300/interactives/Title456-resid321/embed",
+                    "uri": "/interactives/Title456-resid321"
+                }
+            """
 
     Scenario: Update success with only a new file for published interactive
         Given I have these interactives:


### PR DESCRIPTION
### What

Updates to published interactives should be allowed. For example: to allow for fixing an already published interactive the journey would be:
- new collection
- link interactive to published collection
- edit interactive metadata/zip file
- publish collection

We have redirect logic capturing misspellings of the slug so the old URL will redirect to new URL/content.

### How to review

👀 

### Who can review

💻 
