### PR TITLE
Add collection_id to event

### DIFF
--- a/api/interactives.go
+++ b/api/interactives.go
@@ -87,6 +87,7 @@ func (api *API) UploadInteractivesHandler(w http.ResponseWriter, r *http.Request
 
 	// 5. send kafka message to importer
 	err = api.producer.InteractiveUploaded(&event.InteractiveUploaded{
+		CollectionID: interactive.Metadata.CollectionID,
 		ID:           id,
 		FilePath:     uri,
 		Title:        interactive.Metadata.Title,

--- a/event/event.go
+++ b/event/event.go
@@ -3,6 +3,7 @@ package event
 type InteractiveUploaded struct {
 	FilePath     string   `avro:"path"`
 	ID           string   `avro:"id"`
+	CollectionID string   `avro:"collection_id"`
 	Title        string   `avro:"title"`
 	CurrentFiles []string `avro:"current_files"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -8,6 +8,7 @@ var interactiveUploadedEvent = `{
   "type": "record",
   "name": "interactive-uploaded",
   "fields": [
+    {"name": "collection_id", "type": "string"},
     {"name": "id", "type": "string"},
     {"name": "path", "type": "string"},
     {"name": "title", "type": "string"},


### PR DESCRIPTION
### What

We are hitting file already exists errors with files api because we are using the same zip and have no collection context in filename. As we now have the collection before an interactive we can add to the event and mitigate this problem.

### How to review

👀 

### Who can review

💻 
