### PR TITLE
Optimising for streaming large files

### DIFF
--- a/api/archive.go
+++ b/api/archive.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"archive/zip"
-	"bytes"
 	"path/filepath"
 	"strings"
 
@@ -19,9 +18,8 @@ var (
 //so zebedee collection json populated as expected for preview
 //because we process the zip async - zebedee doesnt get this info quick enough
 
-func Open(name string, zipFile []byte) (*models.Archive, error) {
-	size := int64(len(zipFile))
-	zipReader, err := zip.NewReader(bytes.NewReader(zipFile), size)
+func Open(name string) (*models.Archive, error) {
+	zipReader, err := zip.OpenReader(name)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +52,6 @@ func Open(name string, zipFile []byte) (*models.Archive, error) {
 
 	return &models.Archive{
 		Name:  name,
-		Size:  size,
 		Files: htmlFiles,
 	}, nil
 }

--- a/api/archive.go
+++ b/api/archive.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"archive/zip"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -19,6 +20,11 @@ var (
 //because we process the zip async - zebedee doesnt get this info quick enough
 
 func Open(name string) (*models.Archive, error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
 	zipReader, err := zip.OpenReader(name)
 	if err != nil {
 		return nil, err
@@ -51,7 +57,7 @@ func Open(name string) (*models.Archive, error) {
 	}
 
 	return &models.Archive{
-		Name:  name,
+		Size:  fi.Size(),
 		Files: htmlFiles,
 	}, nil
 }

--- a/api/archive_test.go
+++ b/api/archive_test.go
@@ -13,22 +13,25 @@ import (
 
 func TestArchive(t *testing.T) {
 
-	Convey("Given an empty file", t, func() {
+	Convey("Given an invalid zip file", t, func() {
+		archive, err := os.CreateTemp("", "test-zip_*.zip")
+		So(err, ShouldBeNil)
+		defer os.Remove(archive.Name())
 		Convey("Then there should an error returned when attempt to open", func() {
-			a, err := api.Open("name", nil)
+			a, err := api.Open(archive.Name())
 			So(err, ShouldBeError, zip.ErrFormat)
 			So(a, ShouldBeNil)
 		})
 	})
 
 	Convey("Given a valid zip file", t, func() {
-		archiveName, b, err := createTestZip("root.css", "root.html", "root.js", "index.html")
+		archiveName, _, err := createTestZip("root.css", "root.html", "root.js", "index.html")
 		defer os.Remove(archiveName)
 		So(err, ShouldBeNil)
 		So(archiveName, ShouldNotBeEmpty)
 
 		Convey("Then open should run successfully", func() {
-			a, err := api.Open(archiveName, b)
+			a, err := api.Open(archiveName)
 			So(err, ShouldBeNil)
 
 			Convey("And files in archive should be 4", func() {
@@ -38,13 +41,13 @@ func TestArchive(t *testing.T) {
 	})
 
 	Convey("Given an invalid zip file (no .html file present)", t, func() {
-		archiveName, b, err := createTestZip("root.css", "root.js")
+		archiveName, _, err := createTestZip("root.css", "root.js")
 		defer os.Remove(archiveName)
 		So(err, ShouldBeNil)
 		So(archiveName, ShouldNotBeEmpty)
 
 		Convey("Then open should run successfully", func() {
-			a, err := api.Open(archiveName, b)
+			a, err := api.Open(archiveName)
 			So(err, ShouldEqual, api.ErrNoIndexHtml)
 			So(a, ShouldBeNil)
 		})

--- a/api/formdata.go
+++ b/api/formdata.go
@@ -64,8 +64,12 @@ func (f *FormDataRequest) validate(attachmentValidator FormDataValidator) (errs 
 	var err error
 	var filename string
 
-	// Expecting 1 file attachment - only zip
-	if err = f.req.ParseMultipartForm(maxUploadFileSizeMb << 20); err != nil {
+	// maxMemory needs to be manageable for containerised envs like Nomad:
+	// 		ParseMultipartForm parses a request body as multipart/form-data.
+	// 		The whole request body is parsed and up to a total of maxMemory bytes of
+	// 		its file parts are stored in memory, with the remainder stored on
+	// 		disk in temporary files.
+	if err = f.req.ParseMultipartForm(10 << 20); err != nil {
 		msg := fmt.Sprintf("error parsing form data %s", err.Error())
 		errs = append(errs, validatorError(FileFieldKey, msg))
 	}

--- a/api/formdata.go
+++ b/api/formdata.go
@@ -46,9 +46,10 @@ var (
 type FormDataRequest struct {
 	req                 *http.Request
 	api                 *API
-	FileName            string
+	Name                string
 	Interactive         *models.Interactive
 	isMetadataMandatory bool
+	TmpFileName         string
 }
 
 func newFormDataRequest(req *http.Request, api *API, attachmentValidator FormDataValidator, metadataMandatory bool) (*FormDataRequest, []error) {
@@ -62,7 +63,7 @@ func newFormDataRequest(req *http.Request, api *API, attachmentValidator FormDat
 
 func (f *FormDataRequest) validate(attachmentValidator FormDataValidator) (errs []error) {
 	var err error
-	var filename string
+	var tmpfilename, filename string
 
 	// maxMemory needs to be manageable for containerised envs like Nomad:
 	// 		ParseMultipartForm parses a request body as multipart/form-data.
@@ -115,7 +116,8 @@ func (f *FormDataRequest) validate(attachmentValidator FormDataValidator) (errs 
 				errs = append(errs, validatorError(FileFieldKey, msg))
 			}
 
-			filename = tmpZip.Name()
+			tmpfilename = tmpZip.Name()
+			filename = fileHeader.Filename
 		}
 
 		if err = attachmentValidator(f.req); err != nil {
@@ -157,7 +159,8 @@ func (f *FormDataRequest) validate(attachmentValidator FormDataValidator) (errs 
 	}
 
 	if len(errs) == 0 {
-		f.FileName = filename
+		f.TmpFileName = tmpfilename
+		f.Name = filename
 		f.Interactive = interactive
 	}
 

--- a/api/interactives_test.go
+++ b/api/interactives_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ONSdigital/dp-net/v2/responder"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	s3Mock "github.com/ONSdigital/dp-interactives-api/upload/mock"
 	kafka "github.com/ONSdigital/dp-kafka/v3"
 	kMock "github.com/ONSdigital/dp-kafka/v3/kafkatest"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,7 @@ var (
 
 func TestUploadAndUpdateInteractivesHandlers(t *testing.T) {
 	t.Parallel()
+	log.SetDestination(io.Discard, io.Discard)
 
 	type request struct {
 		uri          string
@@ -201,6 +204,7 @@ func TestUploadAndUpdateInteractivesHandlers(t *testing.T) {
 
 func TestUploadInteractivesHandlers(t *testing.T) {
 	t.Parallel()
+	log.SetDestination(io.Discard, io.Discard)
 
 	ctx := context.Background()
 
@@ -275,6 +279,8 @@ func TestUploadInteractivesHandlers(t *testing.T) {
 
 func TestGetInteractiveMetadataHandler(t *testing.T) {
 	t.Parallel()
+	log.SetDestination(io.Discard, io.Discard)
+
 	interactiveID := "11-22-33-44"
 	tests := []struct {
 		title             string


### PR DESCRIPTION
- sha dropped (we read full file for hashing)
- io.Copy is mem efficient according to my googling 😆 